### PR TITLE
documentation of MFA office365 in headless

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,24 @@ docker run -t -i --rm \
 ```
 
 Please note that the `--rm` modifier destroy the docker after shell exit.
+
+
+## MFA Office365
+
+The headless version of davmail does not yet support a shell based authentication 
+process to log in with a second factor.
+
+A workaround is to install the GUI enabled davmail on a desktop and authenticate with 
+the `O365Interactive` method. After successful authentication, it is possible to extract the
+`davmail.oauth.<user@email.tld>.refreshToken={AES}...` from the `.davmail.properties` file.
+
+Copy this key to your server configuration and set the connection mode to
+
+```
+davmail.enableEws=EWS
+davmail.authenticator=davmail.exchange.auth.O365Authenticator
+
+davmail.oauth.<user@email.tld>.refreshToken={AES}...
+```
+
+When a client connects to the davmail bridge, the password is used to decrypt the authentication token.


### PR DESCRIPTION
As I did not find documentation of how to get MFA enforced office365 running in headless, maybe this helps someone else.
I found the correct authentication class by looking at 
https://github.com/mguessan/davmail/blob/395d660b0ae8386e123b5c9280ecbbc64d4b5f23/src/java/davmail/exchange/ExchangeSessionFactory.java#L163